### PR TITLE
feat: added an edit button on note card in user profile

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -5,7 +5,7 @@ import { getNoteCardTransform } from '@/utils/noteCardTransforms'
 import { truncate } from '@/utils/strings'
 import { tiptapJSONtoPlainText } from '@/utils/tiptap'
 import { paths } from '@/utils/urls'
-import { Share2Icon } from 'lucide-react'
+import { EditIcon, Share2Icon } from 'lucide-react'
 import Link from 'next/link'
 import NoteCardFlipper from './NoteCardFlipper'
 import ProfileCard from './ProfileCard'
@@ -71,6 +71,16 @@ export default function NoteCard({
               {note.created_by?.name && (
                 <ProfileCard profile={note.created_by} />
               )}
+
+              {note.is_owner && (
+              <Button mode="bleed" tone="secondary" size="xs" asChild>
+                    <Link href={paths.editNote(note.handle)}>
+                      <EditIcon className="w-[1.25em]" />
+                      Editar
+                    </Link>
+              </Button>
+              )}
+
               <Button
                 size="sm"
                 asChild

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -126,6 +126,7 @@ export type NoteCardData = Omit<
   published_at: Date | string
   /** In UserProfilePage (userProfilePageQuery), created_by isn't fetched */
   created_by?: NoteForCardResult['created_by']
+  is_owner?: boolean | null
 }
 
 const vegetableVarietyForCard = e.shape(e.VegetableVariety, (variety) => ({
@@ -1066,6 +1067,7 @@ export const profileNotesQuery = e.params(
         order_by: {
           expression: e.random(),
         },
+        is_owner: e.op(profile.id, '=', e.global.current_user_profile.id),
       })),
 
       note_count: e.count(


### PR DESCRIPTION
Please consider this possible solution/improvement to add an edit button to the notes displayed in the user profile to improve usability. We can discuss the solution before merging. Thanks